### PR TITLE
correct package name and return array instead of vectors

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -25,7 +25,7 @@ kerasjs_convert <- function(
 
   py_os <- reticulate::import("os")
   py_getcwd <- py_os$getcwd()
-  py_os$chdir(system.file("python", package = "tfconvert"))
+  py_os$chdir(system.file("python", package = "kerasjs"))
   on.exit(py_os$chdir(py_getcwd), add = TRUE)
 
   py_subprocess <- reticulate::import("subprocess")

--- a/R/preview.R
+++ b/R/preview.R
@@ -7,16 +7,15 @@ file_replace <- function(path, pattern, replacement) {
 tensor_build_example <- function(tensor) {
   layer_dims <- tensor$shape$as_list()
   sequence_dim <- Filter(is.integer, layer_dims)
-  rep(0, sequence_dim)
+  input_array <- array(0, dim = unlist(sequence_dim))
+  list(input = input_array)
 }
 
 #' @importFrom keras load_model_hdf5
 kerasjs_input_examples <- function(model_path) {
   model <- load_model_hdf5(model_path, compile = FALSE)
   if ("keras.models.Sequential" %in% class(model)) {
-    list(
-      input = tensor_build_example(model$input)
-    )
+    input = tensor_build_example(model$input)
   }
   else {
     example <- lapply(
@@ -71,7 +70,9 @@ kerasjs_preview <- function(model_path, kerasjs_model) {
 
   models_rel_file <- file.path("models", basename(kerasjs_model))
   file_replace(index_path, "\\%KERAJS_MODEL\\%", models_rel_file)
-  file_replace(index_path, "\\%KERAJS_EXAMPLE\\%", toJSON(kerasjs_input_examples(model_path)))
+  file_replace(index_path,
+               "\\%KERAJS_EXAMPLE\\%",
+               toJSON(kerasjs_input_examples(model_path)))
 
   httd(path)
 }

--- a/R/preview.R
+++ b/R/preview.R
@@ -34,7 +34,7 @@ kerasjs_input_examples <- function(model_path) {
 }
 
 kerasjs_preview_source <- function(path) {
-  source_file <- system.file("scafold/source.html", package = "tfconvert")
+  source_file <- system.file("scafold/source.html", package = "kerasjs")
   readLines(source_file)
 }
 


### PR DESCRIPTION
- changed `tfconvert` to `kerasjs`
- return array of zeros instead of `rep(0, sequence_dim)`. In the MNIST example, the result is exactly the same